### PR TITLE
Use sqlalchemy events to mutate models

### DIFF
--- a/development_requirements.txt
+++ b/development_requirements.txt
@@ -1,3 +1,4 @@
 nose
 sqlalchemy
 six
+black

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_packages():
 
 
 setup(name='statu',
-      version='0.3.2',
+      version='0.3.3',
       description='Python State Machines for Humans',
       url='http://github.com/DisruptiveLabs/statu',
       author='Disruptive Labs',

--- a/statu/__init__.py
+++ b/statu/__init__.py
@@ -22,8 +22,10 @@ def before(before_what):
         frame = inspect.currentframe()
         calling_class = get_function_name(frame)
 
-        calling_class_dict = get_callback_cache().setdefault(calling_class, {'before': {}, 'after': {}})
-        calling_class_dict['before'].setdefault(before_what, []).append(func)
+        calling_class_dict = get_callback_cache().setdefault(
+            calling_class, {"before": {}, "after": {}}
+        )
+        calling_class_dict["before"].setdefault(before_what, []).append(func)
 
         return func
 
@@ -35,8 +37,10 @@ def after(after_what):
         frame = inspect.currentframe()
         calling_class = get_function_name(frame)
 
-        calling_class_dict = get_callback_cache().setdefault(calling_class, {'before': {}, 'after': {}})
-        calling_class_dict['after'].setdefault(after_what, []).append(func)
+        calling_class_dict = get_callback_cache().setdefault(
+            calling_class, {"before": {}, "after": {}}
+        )
+        calling_class_dict["after"].setdefault(after_what, []).append(func)
 
         return func
 
@@ -53,6 +57,6 @@ def acts_as_state_machine(original_class):
 
 def with_state_machine_events(clazz):
     global _temp_callback_cache
-    setattr(clazz, 'callback_cache', _temp_callback_cache)
+    setattr(clazz, "callback_cache", _temp_callback_cache)
     _temp_callback_cache = None
     return clazz

--- a/statu/models/__init__.py
+++ b/statu/models/__init__.py
@@ -3,6 +3,7 @@ try:
 except NameError:
     string_type = str
 
+
 class InvalidStateTransition(Exception):
     pass
 
@@ -11,7 +12,7 @@ class State(object):
     def __init__(self, initial=False, **kwargs):
         self.initial = initial
 
-    def __eq__(self,other):
+    def __eq__(self, other):
         if isinstance(other, string_type):
             return self.name == other
         elif isinstance(other, State):
@@ -19,16 +20,15 @@ class State(object):
         else:
             return False
 
-
     def __ne__(self, other):
         return not self == other
 
 
 class Event(object):
     def __init__(self, **kwargs):
-        self.to_state = kwargs.get('to_state', None)
+        self.to_state = kwargs.get("to_state", None)
         self.from_states = tuple()
-        from_state_args = kwargs.get('from_states', tuple())
+        from_state_args = kwargs.get("from_states", tuple())
         if isinstance(from_state_args, (tuple, list)):
             self.from_states = tuple(from_state_args)
         else:

--- a/statu/orm/base.py
+++ b/statu/orm/base.py
@@ -8,10 +8,12 @@ from statu.models import Event, State, InvalidStateTransition
 def _get_callbacks(self, when, event_name):
     callbacks = []
     for clazz in inspect.getmro(self.__class__):
-        if hasattr(clazz, 'callback_cache') and clazz.callback_cache:
+        if hasattr(clazz, "callback_cache") and clazz.callback_cache:
             if clazz.__name__ in clazz.callback_cache:
                 if event_name in clazz.callback_cache[clazz.__name__][when]:
-                    callbacks.extend(clazz.callback_cache[clazz.__name__][when][event_name])
+                    callbacks.extend(
+                        clazz.callback_cache[clazz.__name__][when][event_name]
+                    )
     return callbacks
 
 
@@ -45,7 +47,9 @@ class BaseAdaptor(object):
     def process_states(self, original_class):
         initial_state = None
         is_method_dict = dict()
-        for member, value in self.get_potential_state_machine_attributes(original_class):
+        for member, value in self.get_potential_state_machine_attributes(
+            original_class
+        ):
 
             if isinstance(value, State):
                 if value.initial:
@@ -54,7 +58,7 @@ class BaseAdaptor(object):
                     initial_state = value
 
                 # add its name to itself:
-                setattr(value, 'name', member)
+                setattr(value, "name", member)
 
                 is_method_string = "is_" + member
 
@@ -72,7 +76,9 @@ class BaseAdaptor(object):
         _adaptor = self
         event_method_dict = dict()
         events = {}
-        for member, value in self.get_potential_state_machine_attributes(original_class):
+        for member, value in self.get_potential_state_machine_attributes(
+            original_class
+        ):
             if isinstance(value, Event):
                 # Create event methods
 
@@ -84,26 +90,28 @@ class BaseAdaptor(object):
 
                         # fire before_change
                         failed = False
-                        for callback in _get_callbacks(self, 'before', event_name):
+                        for callback in _get_callbacks(self, "before", event_name):
                             result = callback(self)
                             if result is False:
-                                print("One of the 'before' callbacks returned false, breaking")
+                                print(
+                                    "One of the 'before' callbacks returned false, breaking"
+                                )
                                 failed = True
                                 break
 
-                        #change state
+                        # change state
                         if not failed:
                             _adaptor.update(self, event_description.to_state.name)
 
-                            #fire after_change
-                            for callback in _get_callbacks(self, 'after', event_name):
+                            # fire after_change
+                            for callback in _get_callbacks(self, "after", event_name):
                                 callback(self)
 
                     return f
 
                 event_method_dict[member] = event_meta_method(member, value)
                 events[member] = value
-        event_method_dict['get_events'] = lambda self: events
+        event_method_dict["get_events"] = lambda self: events
         return event_method_dict
 
     def modifed_class(self, original_class, callback_cache):
@@ -111,7 +119,7 @@ class BaseAdaptor(object):
         class_name = original_class.__name__
         class_dict = dict()
 
-        class_dict['callback_cache'] = callback_cache
+        class_dict["callback_cache"] = callback_cache
 
         def current_state_method():
             def f(self):
@@ -119,9 +127,9 @@ class BaseAdaptor(object):
 
             return property(f)
 
-        class_dict['current_state'] = current_state_method()
-        class_dict['get_next_event_names'] = _get_next_event_names
-        class_dict['get_next_event_methods'] = _get_next_event_methods
+        class_dict["current_state"] = current_state_method()
+        class_dict["get_next_event_names"] = _get_next_event_names
+        class_dict["get_next_event_methods"] = _get_next_event_methods
 
         # Get states
         state_method_dict, initial_state = self.process_states(original_class)

--- a/test_statu.py
+++ b/test_statu.py
@@ -20,14 +20,16 @@ def requires_sqlalchemy(func):
         return pytest.mark.skip(func)
     return func
 
+
 ###############################################################################
 # Plain Old In Memory Tests
 ###############################################################################
 
+
 def test_state_machine():
     @acts_as_state_machine
-    class Robot():
-        name = 'R2-D2'
+    class Robot:
+        name = "R2-D2"
 
         sleeping = State(initial=True)
         running = State()
@@ -37,24 +39,24 @@ def test_state_machine():
         cleanup = Event(from_states=running, to_state=cleaning)
         sleep = Event(from_states=(running, cleaning), to_state=sleeping)
 
-        @before('sleep')
+        @before("sleep")
         def do_one_thing(self):
             print("{} is sleepy".format(self.name))
 
-        @before('sleep')
+        @before("sleep")
         def do_another_thing(self):
             print("{} is REALLY sleepy".format(self.name))
 
-        @after('sleep')
+        @after("sleep")
         def snore(self):
             print("Zzzzzzzzzzzz")
 
-        @after('sleep')
+        @after("sleep")
         def snore(self):
             print("Zzzzzzzzzzzzzzzzzzzzzz")
 
     robot = Robot()
-    assert robot.current_state == 'sleeping'
+    assert robot.current_state == "sleeping"
     assert robot.is_sleeping
     assert not robot.is_running
     robot.run()
@@ -65,8 +67,8 @@ def test_state_machine():
 
 def test_state_machine_no_callbacks():
     @acts_as_state_machine
-    class Robot():
-        name = 'R2-D2'
+    class Robot:
+        name = "R2-D2"
 
         sleeping = State(initial=True)
         running = State()
@@ -77,7 +79,7 @@ def test_state_machine_no_callbacks():
         sleep = Event(from_states=(running, cleaning), to_state=sleeping)
 
     robot = Robot()
-    assert robot.current_state == 'sleeping'
+    assert robot.current_state == "sleeping"
     assert robot.is_sleeping
     assert not robot.is_running
     robot.run()
@@ -97,7 +99,7 @@ def test_multiple_machines():
         cleanup = Event(from_states=running, to_state=cleaning)
         sleep = Event(from_states=(running, cleaning), to_state=sleeping)
 
-        @before('run')
+        @before("run")
         def on_run(self):
             things_done.append("Person.ran")
 
@@ -109,15 +111,15 @@ def test_multiple_machines():
         run = Event(from_states=sleeping, to_state=running)
         sleep = Event(from_states=(running,), to_state=sleeping)
 
-        @before('run')
+        @before("run")
         def on_run(self):
             things_done.append("Dog.ran")
 
     things_done = []
     person = Person()
     dog = Dog()
-    assert person.current_state == 'sleeping'
-    assert dog.current_state == 'sleeping'
+    assert person.current_state == "sleeping"
+    assert dog.current_state == "sleeping"
     assert person.is_sleeping
     assert dog.is_sleeping
     person.run()
@@ -133,27 +135,27 @@ def test_state_machine_inheritance():
         run = Event(from_states=sleeping, to_state=running)
         sleep = Event(from_states=(running,), to_state=sleeping)
 
-        @before('run')
+        @before("run")
         def on_run(self):
             things_done.append("Dog.ran")
 
     @with_state_machine_events
     class Puppy(Dog):
-        @before('run')
+        @before("run")
         def on_sleep(self):
             things_done.append("Puppy.ran_fast")
 
     things_done = []
     dog = Dog()
     puppy = Puppy()
-    assert dog.current_state == 'sleeping'
-    assert puppy.current_state == 'sleeping'
+    assert dog.current_state == "sleeping"
+    assert puppy.current_state == "sleeping"
 
     assert dog.is_sleeping
     assert puppy.is_sleeping
     dog.run()
     puppy.run()
-    assert things_done == ['Dog.ran', 'Puppy.ran_fast', 'Dog.ran']
+    assert things_done == ["Dog.ran", "Puppy.ran_fast", "Dog.ran"]
 
 
 ###################################################################################
@@ -165,11 +167,11 @@ def test_sqlalchemy_state_machine():
     from sqlalchemy.orm import sessionmaker
 
     Base = declarative_base()
-    engine = sqlalchemy.create_engine('sqlite:///:memory:', echo=True)
+    engine = sqlalchemy.create_engine("sqlite:///:memory:", echo=True)
 
     @acts_as_state_machine
     class Puppy(Base):
-        __tablename__ = 'puppies'
+        __tablename__ = "puppies"
         id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
         name = sqlalchemy.Column(sqlalchemy.String)
 
@@ -181,19 +183,19 @@ def test_sqlalchemy_state_machine():
         cleanup = Event(from_states=running, to_state=cleaning)
         sleep = Event(from_states=(running, cleaning), to_state=sleeping)
 
-        @before('sleep')
+        @before("sleep")
         def do_one_thing(self):
             print("{} is sleepy".format(self.name))
 
-        @before('sleep')
+        @before("sleep")
         def do_another_thing(self):
             print("{} is REALLY sleepy".format(self.name))
 
-        @after('sleep')
+        @after("sleep")
         def snore(self):
             print("Zzzzzzzzzzzz")
 
-        @after('sleep')
+        @after("sleep")
         def snore(self):
             print("Zzzzzzzzzzzzzzzzzzzzzz")
 
@@ -202,7 +204,7 @@ def test_sqlalchemy_state_machine():
     Session = sessionmaker(bind=engine)
     session = Session()
 
-    puppy = Puppy(name='Ralph')
+    puppy = Puppy(name="Ralph")
 
     assert puppy.current_state == Puppy.sleeping
     assert puppy.is_sleeping
@@ -225,11 +227,11 @@ def test_sqlalchemy_state_machine_with_hybrid_property():
     from sqlalchemy.orm import sessionmaker
 
     Base = declarative_base()
-    engine = sqlalchemy.create_engine('sqlite:///:memory:', echo=True)
+    engine = sqlalchemy.create_engine("sqlite:///:memory:", echo=True)
 
     @acts_as_state_machine
     class Puppy(Base):
-        __tablename__ = 'puppies'
+        __tablename__ = "puppies"
         id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
         name = sqlalchemy.Column(sqlalchemy.String)
 
@@ -250,7 +252,7 @@ def test_sqlalchemy_state_machine_with_hybrid_property():
     Session = sessionmaker(bind=engine)
     session = Session()
 
-    puppy = Puppy(name='Ralph')
+    puppy = Puppy(name="Ralph")
     puppy2 = Puppy()
 
     session.add(puppy)
@@ -267,11 +269,11 @@ def test_sqlalchemy_state_machine_with_is_hybrid_properties():
     from sqlalchemy.orm import sessionmaker
 
     Base = declarative_base()
-    engine = sqlalchemy.create_engine('sqlite:///:memory:', echo=True)
+    engine = sqlalchemy.create_engine("sqlite:///:memory:", echo=True)
 
     @acts_as_state_machine
     class Puppy(Base):
-        __tablename__ = 'puppies_with_properties'
+        __tablename__ = "puppies_with_properties"
         id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
         name = sqlalchemy.Column(sqlalchemy.String)
 
@@ -288,7 +290,7 @@ def test_sqlalchemy_state_machine_with_is_hybrid_properties():
     Session = sessionmaker(bind=engine)
     session = Session()
 
-    session.add(Puppy(name='Ralph'))
+    session.add(Puppy(name="Ralph"))
     session.commit()
 
     assert session.query(Puppy).filter(Puppy.is_sleeping).all()
@@ -297,17 +299,17 @@ def test_sqlalchemy_state_machine_with_is_hybrid_properties():
 
 @requires_sqlalchemy
 def test_sqlalchemy_state_machine_no_callbacks():
-    ''' This is to make sure that the state change will still work even if no callbacks are registered.
-    '''
+    """ This is to make sure that the state change will still work even if no callbacks are registered.
+    """
     from sqlalchemy.ext.declarative import declarative_base
     from sqlalchemy.orm import sessionmaker
 
     Base = declarative_base()
-    engine = sqlalchemy.create_engine('sqlite:///:memory:', echo=True)
+    engine = sqlalchemy.create_engine("sqlite:///:memory:", echo=True)
 
     @acts_as_state_machine
     class Kitten(Base):
-        __tablename__ = 'kittens'
+        __tablename__ = "kittens"
         id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
         name = sqlalchemy.Column(sqlalchemy.String)
 
@@ -324,7 +326,7 @@ def test_sqlalchemy_state_machine_no_callbacks():
     Session = sessionmaker(bind=engine)
     session = Session()
 
-    kitten = Kitten(name='Kit-Kat')
+    kitten = Kitten(name="Kit-Kat")
 
     assert kitten.current_state == Kitten.sleeping
     assert kitten.is_sleeping
@@ -342,17 +344,17 @@ def test_sqlalchemy_state_machine_no_callbacks():
 
 @requires_sqlalchemy
 def test_sqlalchemy_state_machine_using_initial_state():
-    ''' This is to make sure that the database will save the object with the initial state.
-    '''
+    """ This is to make sure that the database will save the object with the initial state.
+    """
     from sqlalchemy.ext.declarative import declarative_base
     from sqlalchemy.orm import sessionmaker
 
     Base = declarative_base()
-    engine = sqlalchemy.create_engine('sqlite:///:memory:', echo=True)
+    engine = sqlalchemy.create_engine("sqlite:///:memory:", echo=True)
 
     @acts_as_state_machine
     class Penguin(Base):
-        __tablename__ = 'penguins'
+        __tablename__ = "penguins"
         id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
         name = sqlalchemy.Column(sqlalchemy.String)
 
@@ -370,7 +372,7 @@ def test_sqlalchemy_state_machine_using_initial_state():
     session = Session()
 
     # Note: No state transition occurs between the initial state and when it's saved to the database.
-    penguin = Penguin(name='Tux')
+    penguin = Penguin(name="Tux")
     assert penguin.current_state == Penguin.sleeping
     assert penguin.is_sleeping
 
@@ -384,8 +386,8 @@ def test_sqlalchemy_state_machine_using_initial_state():
 
 def test_events_and_next_event_names():
     @acts_as_state_machine
-    class Robot():
-        name = 'R2-D2'
+    class Robot:
+        name = "R2-D2"
 
         sleeping = State(initial=True)
         running = State()
@@ -395,31 +397,31 @@ def test_events_and_next_event_names():
         cleanup = Event(from_states=running, to_state=cleaning)
         sleep = Event(from_states=(running, cleaning), to_state=sleeping)
 
-        @before('sleep')
+        @before("sleep")
         def do_one_thing(self):
             print("{} is sleepy".format(self.name))
 
-        @before('sleep')
+        @before("sleep")
         def do_another_thing(self):
             print("{} is REALLY sleepy".format(self.name))
 
-        @after('sleep')
+        @after("sleep")
         def snore(self):
             print("Zzzzzzzzzzzz")
 
-        @after('sleep')
+        @after("sleep")
         def snore(self):
             print("Zzzzzzzzzzzzzzzzzzzzzz")
 
     robot = Robot()
-    assert robot.current_state == 'sleeping'
+    assert robot.current_state == "sleeping"
     assert robot.is_sleeping
     assert not robot.is_running
     events = robot.get_events()
     event_names = events.keys()
-    assert sorted(event_names) == sorted(['sleep', 'cleanup', 'run'])
+    assert sorted(event_names) == sorted(["sleep", "cleanup", "run"])
     next_event_names = robot.get_next_event_names()
-    assert next_event_names == ['run']
+    assert next_event_names == ["run"]
     dynamic_event_name = next_event_names[0]
     dynamic_event_method = getattr(robot, dynamic_event_name)
     dynamic_event_method()
@@ -427,15 +429,15 @@ def test_events_and_next_event_names():
 
     # Demonstrate getting the next event method using getattr with the event name.
     next_event_names = robot.get_next_event_names()
-    assert sorted(next_event_names) == sorted(['cleanup', 'sleep'])
-    dynamic_event_name = 'sleep'
+    assert sorted(next_event_names) == sorted(["cleanup", "sleep"])
+    dynamic_event_name = "sleep"
     dynamic_event_method = getattr(robot, dynamic_event_name)
     dynamic_event_method()
     assert robot.is_sleeping
 
     # Demonstrate getting the next event method using the get_next_events method.
     next_event_methods = robot.get_next_event_methods()
-    assert list(next_event_methods.keys()) == ['run']
-    dynamic_event_method = next_event_methods['run']
+    assert list(next_event_methods.keys()) == ["run"]
+    dynamic_event_method = next_event_methods["run"]
     dynamic_event_method()
     assert robot.is_running

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,8 @@
 [tox]
 envlist =
-     py27
-     py33
-     py34
-     py35
      py36
+     py37
+     py38
      pypy
 [testenv]
 deps=sqlalchemy


### PR DESCRIPTION
This gets around the need to iterate attributes of the models
 during instantiation, which fixes a lot of circular dependency
 issues

I had to move aasm_state outside the event, so that other parts
 of the codebase can access that before mapper configuration is
 complete.